### PR TITLE
Fixed bugs in spacing different styled texts

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,11 +22,10 @@ class _StyledPageState extends State<StyledPage> {
         body: Padding(
           padding: const EdgeInsets.all(8.0),
           child: SingleChildScrollView(
-            child: Wrap(
-              children: TextStyled().getStyledTextWidgets(
-                  "This is normal text [color=blue]blue text[/color] with [b]bold text[/b] [i]italic text[/i] [u]underlined text[/u] and [color=0xFFFFD600][b][i][u]mixed styled[/b][/i][/u][/color] and [a=https://pub.dev/packages/flutter_text_styled] link to open pub.dev[/a]"),
-            ),
-          ),
+              child: TextStyled(
+                      textStyle: TextStyle(fontSize: 30, color: Colors.red))
+                  .getRichText(
+                      "This is normal text [color=blue]blue text[/color] with [b]bold text[/b] [i]italic text[/i] [u]underlined text[/u] and [color=0xFFFFD600][b][i][u]mixed styled[/b][/i][/u][/color] and [a=https://pub.dev/packages/flutter_text_styled]link to open pub.dev[/a]")),
         ),
       ),
     );

--- a/lib/flutter_text_styled.dart
+++ b/lib/flutter_text_styled.dart
@@ -174,7 +174,11 @@ class TextStyled {
 
   void _addNormalTextWidget(List<Widget> resultWidgets) {
     if (_normalText != null && _normalText!.isNotEmpty) {
-      resultWidgets.add(Text(_normalText!, style: textStyle));
+      resultWidgets.add(Text(
+        _normalText!,
+        style: textStyle,
+        softWrap: true,
+      ));
       _normalText = null;
     }
   }
@@ -215,7 +219,11 @@ class TextStyled {
           break;
       }
     });
-    final textWidget = Text(_styledText!, style: style);
+    final textWidget = Text(
+      _styledText!,
+      style: style,
+      softWrap: true,
+    );
     if (link.isNotEmpty) {
       final gestureDetector = GestureDetector(
           child: textWidget,

--- a/lib/flutter_text_styled.dart
+++ b/lib/flutter_text_styled.dart
@@ -5,7 +5,6 @@ import 'dart:collection';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 enum TAGS { BOLD, ITALIC, UNDERLINE, COLOR, LINK }
 
@@ -45,8 +44,8 @@ class TextStyled {
 
   TextStyled({this.textStyle = const TextStyle()});
 
-  List<Widget> getStyledTextWidgets(String text) {
-    List<Widget> resultWidgets = [];
+  RichText getRichText(String text) {
+    List<TextSpan> resultWidgets = [];
     _remainingText = text;
     while (_remainingText != null && _remainingText!.isNotEmpty) {
       int openTagIndex = _remainingText!.indexOf(_openTagRegExp);
@@ -56,11 +55,11 @@ class TextStyled {
 
       _handleNextTag(openTagIndex, closeTagIndex, resultWidgets);
     }
-    return resultWidgets;
+    return RichText(text: TextSpan(style: textStyle, children: resultWidgets));
   }
 
   void _handleNextTag(
-      int openTagIndex, int closeTagIndex, List<Widget> resultWidgets) {
+      int openTagIndex, int closeTagIndex, List<TextSpan> resultWidgets) {
     if (openTagIndex == -1 && closeTagIndex == -1) {
       _normalText = _remainingText;
       _addNormalTextWidget(resultWidgets);
@@ -143,7 +142,7 @@ class TextStyled {
   }
 
   void _findEndStyledTextIndex(
-      List<Widget> resultWidgets, int openTagIndex, int closeTagIndex) {
+      List<TextSpan> resultWidgets, int openTagIndex, int closeTagIndex) {
     int openTagIndex = _remainingText!.indexOf(_openTagRegExp);
     int closeTagIndex = _remainingText!.indexOf(_closeTagRegExp);
 
@@ -162,7 +161,7 @@ class TextStyled {
     }
   }
 
-  void _generateTextWidgets(List<Widget> resultWidgets) {
+  void _generateTextWidgets(List<TextSpan> resultWidgets) {
     _styledText = _remainingText!.substring(0, _endStyledTextIndex);
     _remainingText =
         _remainingText!.substring(_endStyledTextIndex!, _remainingText!.length);
@@ -172,18 +171,16 @@ class TextStyled {
     _addStyledTextWidget(resultWidgets);
   }
 
-  void _addNormalTextWidget(List<Widget> resultWidgets) {
+  void _addNormalTextWidget(List<TextSpan> resultWidgets) {
     if (_normalText != null && _normalText!.isNotEmpty) {
-      resultWidgets.add(Text(
-        _normalText!,
-        style: textStyle,
-        softWrap: true,
+      resultWidgets.add(TextSpan(
+        text: _normalText!,
       ));
       _normalText = null;
     }
   }
 
-  void _addStyledTextWidget(List<Widget> resultWidgets) {
+  void _addStyledTextWidget(List<TextSpan> resultWidgets) {
     if (_styledText != null && _styledText!.isNotEmpty) {
       resultWidgets.add(_generateTextStyledWidgets());
       _styledText = null;
@@ -195,7 +192,7 @@ class TextStyled {
     _normalText!.replaceAll(_anyTagRegExp, REPLACEMENT_EMPTY_TAG);
   }
 
-  Widget _generateTextStyledWidgets() {
+  TextSpan _generateTextStyledWidgets() {
     TextStyle style = textStyle;
     String link = '';
     _styledTextTags.forEach((tag, value) {
@@ -219,20 +216,10 @@ class TextStyled {
           break;
       }
     });
-    final textWidget = Text(
-      _styledText!,
+    return TextSpan(
+      text: _styledText!,
       style: style,
-      softWrap: true,
     );
-    if (link.isNotEmpty) {
-      final gestureDetector = GestureDetector(
-          child: textWidget,
-          onTap: () {
-            launch(link);
-          });
-      return gestureDetector;
-    }
-    return textWidget;
   }
 
   TextStyle _getColorStyle(String value, TextStyle style) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: ^6.0.2
+  url_launcher: ^5.7.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  url_launcher: ^6.0.3
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: ^5.7.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hello what i did is:
- transfered all the widgets stuff into textSpans
- now returning richText except of List<Widget> so i think it could be helpful and won't generate boilerplate wraps, but in some cases we could ofc customize text RichText params
- updated dependencies

Please merge it with squash commits cuz I've made a big mess in commits (as I've used to do 😢)